### PR TITLE
Allow RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS to be set via Values

### DIFF
--- a/stable/ibm-rabbitmq-dev/templates/rabbitmq-deployment.yaml
+++ b/stable/ibm-rabbitmq-dev/templates/rabbitmq-deployment.yaml
@@ -59,6 +59,8 @@ spec:
         - name: RABBITMQ_CTL_ERL_ARGS
           value: "-proto_dist inet_tls"
         {{ end -}}
+        - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+          value: {{ .Values.rabbitmqServerAdditionalErlArgs | quote }}
         - name: RABBITMQ_NODE_TYPE
           value: {{ .Values.rabbitmqNodeType | quote }}
         - name: RABBITMQ_NODENAME

--- a/stable/ibm-rabbitmq-dev/values-metadata.yaml
+++ b/stable/ibm-rabbitmq-dev/values-metadata.yaml
@@ -132,6 +132,15 @@ rabbitmqErlangCookie:
     immutable: "false"
     required: false
 
+rabbitmqServerAdditionalErlArgs:
+  __metadata:
+    name: "rabbitmqServerAdditionalErlArgs"
+    label: "RabbitMQ Additional Server Args (RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS)"
+    description: "RabbitMQ additional Server configuration. See https://docs.docker.com/samples/library/rabbitmq/#additional-configuration for information on what can be placed in the RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS env var. Defaults to ''"
+    type: "string"
+    immutable: "false"
+    required: false
+
 rabbitmqNodePort:
   __metadata:
     name: "rabbitmqNodePort"

--- a/stable/ibm-rabbitmq-dev/values.yaml
+++ b/stable/ibm-rabbitmq-dev/values.yaml
@@ -33,6 +33,10 @@ rabbitmqPassword: admin
 ## Erlang cookie to determine whether different nodes are allowed to communicate with each other
 rabbitmqErlangCookie: ""
 
+## If additional configuration is required, per rabbitmq doc.
+##It is recommended to use the RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS environment variable
+rabbitmqServerAdditionalErlArgs: ""
+
 ## Node port
 rabbitmqNodePort: 5671
 


### PR DESCRIPTION
Add the ability to set `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` int he deployment.  See https://docs.docker.com/samples/library/rabbitmq/#additional-configuration for more information on this.