### PR TITLE
Update Hazelcast version to 3.10.3

### DIFF
--- a/stable/ibm-hazelcast-dev/templates/deployment.yaml
+++ b/stable/ibm-hazelcast-dev/templates/deployment.yaml
@@ -46,16 +46,16 @@ spec:
           ports:
             - containerPort: 5701
           livenessProbe:
-            exec:
-              command:
-              - "./liveness.sh"
+            httpGet:
+              path: /hazelcast/health/node-state
+              port: 5701
             initialDelaySeconds: 30
             timeoutSeconds: 5
             periodSeconds: 10
           readinessProbe:
-            exec:
-              command:
-              - "./readiness.sh"
+            httpGet:
+              path: /hazelcast/health/node-state
+              port: 5701
             initialDelaySeconds: 30
             timeoutSeconds: 5
             periodSeconds: 10
@@ -71,9 +71,7 @@ spec:
           - name: MAX_HEAP_SIZE
             value: {{ .Values.heap.maxHeapSize }}
           - name: JAVA_OPTS
-            value: {{ .Values.javaOpts }}
-          - name: HZ_DATA
-            value: /data/hazelcast
+            value: "-Dhazelcast.http.healthcheck.enabled=true -Dhazelcast.config=/data/hazelcast/hazelcast.xml {{ .Values.javaOpts }}"
           volumeMounts:
             - name: {{ include "sch.names.fullCompName" (list . $compName) | quote }}
               mountPath: /data/hazelcast

--- a/stable/ibm-hazelcast-dev/values.yaml
+++ b/stable/ibm-hazelcast-dev/values.yaml
@@ -42,14 +42,14 @@ image:
   #   myimage:1.0             <--------  Used in HELM Chart
   #   myimage:1.0_ppc64le
   #   myimage:1.0_x86_64
-  repository: hazelcast/hazelcast-kubernetes
+  repository: hazelcast/hazelcast
  
  
   ## Specify a imagePullPolicy - Always, Never, or IfNotPresent. Defaults to Always
   ## if :latest tag is specified, or IfNotPresent otherwise.
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   pullPolicy: IfNotPresent
-  tag: "3.10"
+  tag: "3.10.3"
 
 # For easy URL access during testing may use NodePort instead of ClusterIP,
 # but for prod ensure the correct type is defaulted.


### PR DESCRIPTION
Update `hazelcast/hazelcast-kubernetes:3.10` to `hazelcast/hazelcast:3.10.3`.

The Docker image `hazelcast/hazelcast-kubernetes` is deprecated and won't be supported up from `3.10.3`.  Instead, the standard Docker image `hazelcast/hazelcast` should be used. That required a few minor changes in the template configuration.