### PR TITLE
Added helm chart for ibm-filebeat-dev for ppc64le

### DIFF
--- a/stable/ibm-filebeat-dev/.helmignore
+++ b/stable/ibm-filebeat-dev/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.jpg
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+

--- a/stable/ibm-filebeat-dev/Chart.yaml
+++ b/stable/ibm-filebeat-dev/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+description: A Helm chart to collect Kubernetes logs with filebeat
+icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
+name: ibm-filebeat-dev
+version: 0.1.1
+appVersion: 5.5.1
+home: https://www.elastic.co/products/beats/filebeat
+sources:
+- https://www.elastic.co/guide/en/beats/filebeat/current/index.html
+maintainers:
+- name: rendhalver
+  email: pete.brown@powerhrg.com
+- name: sstarcher
+  email: shane.starcher@gmail.com
+keywords:
+- filebeat
+- Limited
+- ppc64le
+- Tools
+- ICP
+- Beta
+tillerVersion: '>=2.7.2'
+kubeVersion: ">=1.7.0"
+

--- a/stable/ibm-filebeat-dev/LICENSE
+++ b/stable/ibm-filebeat-dev/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/stable/ibm-filebeat-dev/README.md
+++ b/stable/ibm-filebeat-dev/README.md
@@ -1,0 +1,111 @@
+# Filebeat
+
+## Introduction
+
+[filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/index.html) is used to ship Kubernetes and host logs to multiple outputs.
+
+## Prerequisites
+
+- Kubernetes cluster v1.7+
+- Tiller 2.7.2 or later
+
+## Note
+
+By default this chart only ships a single output to a file on the local system.  Users should set config.output.file.enabled=false and configure their own outputs as [documented](https://www.elastic.co/guide/en/beats/filebeat/current/configuring-output.html)
+
+This chart is validated on ppc64le.
+
+## Resources Required
+The chart deploys pods consuming minimum resources as specified in the resources configuration parameter (default: Memory: 200Mi, CPU: 100m)
+
+## PodSecurityPolicy Requirements
+This chart requires a PodSecurityPolicy to be bound to the target namespace prior to installation. Choose predefined ibm-anyuid-psp PodSecurityPolicy.
+
+## Chart Details
+
+This chart will deploy filebeat.
+
+## Limitations
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/filebeat
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the filebeat chart and their default values.
+
+| Parameter                                                | Description                                                                                              | Default                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `image.repository`                                       | Docker image repo                                                                                        | `docker.elastic.co/beats/filebeat-oss`             |
+| `image.tag`                                              | Docker image tag                                                                                         | `6.5.3`                                            |
+| `image.pullPolicy`                                       | Docker image pull policy                                                                                 | `IfNotPresent`                                     |
+| `image.pullSecrets`                                      | Specify image pull secrets                                                                               | `nil`                                              |
+| `config.filebeat.config.prospectors.path`                | Mounted `filebeat-prospectors` configmap                                                                 | `${path.config}/prospectors.d/*.yml`               |
+| `config.filebeat.config.prospectors.reload.enabled`      | Reload prospectors configs as they change                                                                | `false`                                            |
+| `config.filebeat.config.modules.path`                    |                                                                                                          | `${path.config}/modules.d/*.yml`                   |
+| `config.filebeat.config.modules.reload.enabled`          | Reload module configs as they change                                                                     | `false`                                            |
+| `config.processors`                                      |                                                                                                          | `- add_cloud_metadata`                             |
+| `config.filebeat.prospectors`                            |                                                                                                          | see values.yaml                                    |
+| `config.output.file.path`                                |                                                                                                          | `"/usr/share/filebeat/data"`                       |
+| `config.output.file.filename`                            |                                                                                                          | `filebeat`                                         |
+| `config.output.file.rotate_every_kb`                     |                                                                                                          | `10000`                                            |
+| `config.output.file.number_of_files`                     |                                                                                                          | `5`                                                |
+| `config.http.enabled`                                    |                                                                                                          | `false`                                            |
+| `config.http.port`                                       |                                                                                                          | `5066`                                             |
+| `indexTemplateLoad`                                      | List of Elasticsearch hosts to load index template, when logstash output is used                         | `[]`                                               |
+| `command`                                                | Custom command (Docker Entrypoint)                                                                       | `[]`                                               |
+| `args`                                                   | Custom args (Docker Cmd)                                                                                 | `[]`                                               |
+| `plugins`                                                | List of beat plugins                                                                                     | `[]`                                               |
+| `extraVars`                                              | A list of additional environment variables                                                                | `[]`                                              |
+| `extraVolumes`                                           | Add additional volumes                                                                                   | `[]`                                               |
+| `extraVolumeMounts`                                      | Add additional mounts                                                                                    | `[]`                                               |
+| `extraInitContainers`                                    | Add additional initContainers                                                                            | `[]`                                               |
+| `resources`                                              |                                                                                                          | `{}`                                               |
+|`priorityClassName`                                       | priorityClassName                                                                                        | `nil`                                              |
+| `nodeSelector`                                           |                                                                                                          | `{}`                                               |
+| `annotations`                                            |                                                                                                          | `{}`                                               |
+| `tolerations`                                            |                                                                                                          | `[]`                                               |
+| `affinity`                                               |                                                                                                          | `{}`                                               |
+| `rbac.create`                                            | Specifies whether RBAC resources should be created                                                       | `true`                                             |
+| `serviceAccount.create`                                  | Specifies whether a ServiceAccount should be created                                                     | `true`                                             |
+| `serviceAccount.name`                                    | the name of the ServiceAccount to use                                                                     | `""`                                               |
+| `podSecurityPolicy.enabled`                              | Should the PodSecurityPolicy be created. Depends on `rbac.create` being set to `true`.                                                                     | `false`                                               |
+| `podSecurityPolicy.annotations`                                    | Annotations to be added to the created PodSecurityPolicy:                                                                    | `""`                                               |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/filebeat
+```
+
+## Uninstalling the Chart
+
+* To uninstall/delete the `filebeat` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Support
+
+The helm charts are provided "as-is" and without warranty of any kind.
+
+All helm charts and packages are supported through standard open source forums and helm charts are updated on a best effort basis.
+
+Any issues found can be reported through the links below, and fixes may be proposed/submitted using standard git issues as noted below.
+
+[Submit issue to Helm Chart] ( https://github.com/ppc64le/charts/issues )
+
+[Submit issue to filebeat docker image]  ( https://hub.docker.com/r/ibmcom/filebeat-ppc64le )
+
+[Submit issue to filebeat open source community] ( https://github.com/elastic/beats/issues )
+

--- a/stable/ibm-filebeat-dev/RELEASENOTES.md
+++ b/stable/ibm-filebeat-dev/RELEASENOTES.md
@@ -1,0 +1,20 @@
+# Release Notes
+
+## What's new in Chart Version 1.0
+
+- Initial Release
+
+## Fixes
+
+## Breaking Changes
+
+## Documentation
+
+## Prerequisites
+
+## Version History
+
+| Chart | Date | Kubernetes Version Required | Breaking Changes | Details |
+| ----- | ---- | --------------------------- | ---------------- | ------- |
+| 0.1.0 | January 21, 2019 | >= 1.7 | None | Initial version |
+

--- a/stable/ibm-filebeat-dev/templates/NOTES.txt
+++ b/stable/ibm-filebeat-dev/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that Filebeat has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "filebeat.name" . }},release={{ .Release.Name }}"

--- a/stable/ibm-filebeat-dev/templates/_affinity.tpl
+++ b/stable/ibm-filebeat-dev/templates/_affinity.tpl
@@ -1,0 +1,18 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+#https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ .Values.node }}
+{{- end }}
+

--- a/stable/ibm-filebeat-dev/templates/_helpers.tpl
+++ b/stable/ibm-filebeat-dev/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "filebeat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "filebeat.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "filebeat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "filebeat.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "filebeat.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/ibm-filebeat-dev/templates/clusterrole.yaml
+++ b/stable/ibm-filebeat-dev/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/stable/ibm-filebeat-dev/templates/clusterrolebinding.yaml
+++ b/stable/ibm-filebeat-dev/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "filebeat.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "filebeat.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/ibm-filebeat-dev/templates/daemonset.yaml
+++ b/stable/ibm-filebeat-dev/templates/daemonset.yaml
@@ -1,0 +1,169 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "filebeat.name" . }}
+      release: {{ .Release.Name }}
+  minReadySeconds: 10
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "filebeat.name" . }}
+        release: {{ .Release.Name }}
+        chart: {{ template "filebeat.chart" . }}
+        heritage: {{ .Release.Service }}
+      annotations:
+        productName: filebeat
+        productID: filebeat_{{ .Chart.Version }}
+        productVersion: {{ .Chart.Version }}
+        checksum/secret: {{ toYaml .Values.config | sha256sum }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $sec := .Values.image.pullSecrets }}
+        - name: {{ $sec | quote }}
+      {{- end }}
+    {{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+      initContainers:
+{{- if .Values.indexTemplateLoad }}
+      - name: "load-es-template"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /bin/bash
+        - -c
+        - filebeat setup --template
+          -E output.logstash.enabled=false
+          -E output.file.enabled=false
+          -E output.elasticsearch.hosts=[{{- range $index, $host := .Values.indexTemplateLoad }}{{ if $index }}, {{ end }}{{ $host | quote }}{{- end }}]
+{{- end }}
+{{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 6 }}
+{{- end }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.command }}
+        command:
+{{ toYaml .Values.command | indent 8 }}
+{{- end }}
+        args:
+{{- if .Values.args }}
+{{ toYaml .Values.args | indent 8 }}
+{{- else }}
+        - "filebeat"
+{{- if .Values.plugins }}
+        - "--plugin"
+        - {{ .Values.plugins | join "," | quote }}
+{{- end }}
+{{- end }}
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+{{- if .Values.extraVars }}
+{{ toYaml .Values.extraVars | indent 8 }}
+{{- end }}
+        {{- if index .Values.config "http.enabled" }}
+        ports:
+          - containerPort: {{ index .Values.config "http.port" }}
+        {{- end }}
+        readinessProbe:
+          exec:
+            command:
+            - tail  
+            - /usr/share/filebeat/data/registry
+          initialDelaySeconds: 5
+        livenessProbe:
+          exec:
+            command:
+            - tail  
+            - /usr/share/filebeat/data/registry
+          initialDelaySeconds: 5
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: false
+          runAsUser: 0
+          capabilities:
+           drop:
+            - ALL
+{{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
+        volumeMounts:
+        - name: filebeat-config
+          mountPath: /usr/share/filebeat/filebeat.yml
+          readOnly: true
+          subPath: filebeat.yml
+        - name: data
+          mountPath: /usr/share/filebeat/data
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+      - name: varlog
+        emptyDir: {}
+      - name: varlibdockercontainers
+        emptyDir: {}
+      - name: filebeat-config
+        secret:
+          secretName: {{ template "filebeat.fullname" . }}
+      - name: data
+        emptyDir: {}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: {{ template "filebeat.serviceAccountName" . }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- if .Values.node }}
+      affinity:
+        {{- include "nodeaffinity" . | indent 8 }}
+{{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/ibm-filebeat-dev/templates/podsecuritypolicy.yaml
+++ b/stable/ibm-filebeat-dev/templates/podsecuritypolicy.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.rbac.create -}}
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  annotations:
+{{- if .Values.podSecurityPolicy.annotations }}
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedHostPaths:
+    - pathPrefix: /var/log
+      readOnly: true
+    - pathPrefix: /var/lib/docker/containers
+      readOnly: true
+    - pathPrefix: /var/lib/filebeat
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - configMap
+    - secret
+    - hostPath
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: MustRunAs
+    ranges:
+      - min: 0
+        max: 0
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  hostPorts:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: false
+{{- end -}}
+{{- end -}}

--- a/stable/ibm-filebeat-dev/templates/role.yaml
+++ b/stable/ibm-filebeat-dev/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "filebeat.fullname" . }}
+{{- end }}
+{{- end }}

--- a/stable/ibm-filebeat-dev/templates/rolebinding.yaml
+++ b/stable/ibm-filebeat-dev/templates/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ template "filebeat.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "filebeat.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/stable/ibm-filebeat-dev/templates/secret.yaml
+++ b/stable/ibm-filebeat-dev/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  filebeat.yml: {{ toYaml .Values.config | indent 4 | b64enc }}

--- a/stable/ibm-filebeat-dev/templates/serviceaccount.yaml
+++ b/stable/ibm-filebeat-dev/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "filebeat.serviceAccountName" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/stable/ibm-filebeat-dev/values-metadata.yaml
+++ b/stable/ibm-filebeat-dev/values-metadata.yaml
@@ -1,0 +1,204 @@
+image:
+  __metadata:
+    label: "Image"
+    description: "Docker image details"
+  repository:
+    __metadata:
+      name: "repository"
+      label: "Repository"
+      description: "Docker image location"
+      type: "string"
+      immutable: false
+      required: true
+  tag:
+    __metadata:
+      name: "tag"
+      label: "Tag"
+      description: "Docker image tag"
+      type: "string"
+      immutable: false
+      required: true
+  pullPolicy:
+    __metadata:
+      name: "pullPolicy"
+      label: "Docker image pull policy"
+      description: "Defaults to 'Always' when the latest tag is specified. Otherwise the default is 'IfNotPresent'."
+      type: "string"
+      immutable: false
+      required: true
+      options:
+      - label: "Always"
+        value: "Always"
+      - label: "Never"
+        value: "Never"
+      - label: "IfNotPresent"
+        value: "IfNotPresent"
+  pullSecrets:
+    __metadata:
+      label: "Pull secrets"
+      description: "Specify the pull secrets for the Docker image."
+      type: "string"
+      required: false
+
+node: 
+   __metadata:
+     name: "Node"
+     label: "Node Preference "
+     description: "Select node architecture to deploy chart on"
+     type: "string"
+     immutable: false
+     required: true
+     options:
+     - label: "ppc64le"
+       value: "ppc64le"
+
+tolerations:
+  __metadata:
+    name: "tolerations"
+    label: "Tolerations"
+    description: "Toleration labels for pod assignment, e.g. [{\"key\": \"key\", \"operator\":\"Equal\", \"value\": \"value\", \"effect\":\"NoSchedule\"}]"
+    type: "string"
+    immutable: false
+    required: false
+
+config:
+  __metadata:
+    label: "Config"
+    description: "Configuration Details"
+  processors:
+    __metadata:
+      label: "Processors"
+      description: "Processor to process events before they are sent to the configured output."
+      type: "string"
+      required: false
+  filebeat:
+    prospectors:
+      __metadata:
+        label: "Prospectors"
+        description: "Prospectors that Filebeat uses to locate and process log files"
+        required: false
+  output:
+    file:
+      path:
+        __metadata:
+          label: "Path"
+          description: "The path to the directory where the generated files will be saved."
+          type: "string"
+          required: true
+      filename:
+        __metadata:
+          label: "Filename"
+          description: "The name of the generated files."
+          type: "string"
+          required: false
+      rotate_every_kb:
+        __metadata:
+          label: "RotateEveryKB"
+          description: "The maximum size in kilobytes of each file."
+          type: "number"
+          required: false
+      number_of_files:
+        __metadata:
+          label: "NumberOfFiles"
+          description: "The maximum number of files to save under path."
+          type: "number"
+          required: false
+  http:
+    enabled:
+      __metadata:
+        label: "HttpEnabled"
+        description: "Enable the HTTP endpoint."
+        type: "boolean"
+        required: false
+    port:
+      __metadata:
+        label: "HttpPort"
+        description: "Port on which the HTTP endpoint will bind."
+        type: "number"
+        required: false
+
+indexTemplateLoad:
+  __metadata:
+    label: "IndexTemplateLoad"
+    description: "Upload index template to Elasticsearch if Logstash output is enabled"
+
+plugins:
+  __metadata:
+    label: "Plugins"
+    description: "List of beat plugins"
+
+command:
+  __metadata:
+    label: "Command"
+    description: "pass custom command. This is equivalent of Entrypoint in docker"
+
+args:
+  __metadata:
+    label: "Args"
+    description: "pass custom args. This is equivalent of Cmd in docker"
+
+extraVars:
+  __metadata:
+    label: "ExtraVars"
+    description: "A list of additional environment variables"
+
+extraVolumes:
+  __metadata:
+    label: "ExtraVolumes"
+    description: "Add additional volumes, for example to read other log files on the host"
+
+extraVolumeMounts:
+  __metadata:
+    label: "ExtraVolumeMounts"
+    description: "Add additional mounts, for example to read other log files on the host"
+
+extraInitContainers:
+  __metadata:
+    label: "ExtraInitContainers"
+    description: "Additional containers"
+
+priorityClassName:
+  __metadata:
+    label: "PriorityClassName"
+    description: "Priority Class Name"
+    type: "string"
+
+rbac:
+  __metadata:
+    label: "Rbac"
+    description: "Specifies whether RBAC resources should be created"
+  create:
+    __metadata:
+      label: "Create"
+      description: "Specifies whether RBAC resources should be created"
+      type: "boolean"
+
+serviceAccount:
+  __metadata:
+    label: "ServiceAccount"
+    description: "Specifies whether a ServiceAccount should be created"
+  create:
+    __metadata:
+      label: "Create"
+      description: "Specifies whether a ServiceAccount should be created"
+      type: "boolean"
+  name:
+    __metadata:
+      label: "Name"
+      description: "The name of the ServiceAccount to use"
+      type: "string"
+
+podSecurityPolicy:
+  __metadata:
+    label: "PodSecurityPolicy"
+    description: "Specify if a Pod Security Policy for filebeat must be created"
+  enabled:
+    __metadata:
+      label: "Enabled"
+      description: "Specify if a Pod Security Policy for filebeat must be created"
+      type: "boolean"
+
+
+
+
+

--- a/stable/ibm-filebeat-dev/values.yaml
+++ b/stable/ibm-filebeat-dev/values.yaml
@@ -1,0 +1,122 @@
+image:
+  repository: ibmcom/filebeat-ppc64le
+  tag: 5.5.1
+  pullPolicy: IfNotPresent
+  pullSecrets:
+
+config:
+
+  processors:
+    - add_cloud_metadata:
+
+  filebeat.prospectors:
+    - input_type: log
+      paths:
+        - /var/log/*.log
+        - /var/log/messages
+        - /var/log/syslog
+
+  output.file:
+    path: "/usr/share/filebeat/data"
+    filename: filebeat
+    rotate_every_kb: 10000
+    number_of_files: 5
+
+  # When a key contains a period, use this format for setting values on the command line:
+  # --set config."http\.enabled"=true
+  http.enabled: true
+  http.port: 5066
+
+# Upload index template to Elasticsearch if Logstash output is enabled
+# https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-template.html
+# List of Elasticsearch hosts
+indexTemplateLoad: []
+  # - elasticsearch:9200
+
+# List of beat plugins
+plugins: []
+  # - kinesis.so
+
+# pass custom command. This is equivalent of Entrypoint in docker
+command: []
+
+# pass custom args. This is equivalent of Cmd in docker
+args: []
+
+# A list of additional environment variables
+extraVars: []
+  # - name: TEST1
+  #   value: TEST2
+  # - name: TEST3
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: configmap
+  #       key: config.key
+
+# Add additional volumes and mounts, for example to read other log files on the host
+extraVolumes: []
+  # - hostPath:
+  #     path: /var/log
+  #   name: varlog
+extraVolumeMounts: []
+  # - name: varlog
+  #   mountPath: /host/var/log
+  #   readOnly: true
+
+extraInitContainers: []
+  # - name: echo
+  #   image: busybox
+  #   imagePullPolicy: Always
+  #   args:
+  #     - echo
+  #     - hello
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 200Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 100Mi
+
+priorityClassName: ""
+
+nodeSelector: {}
+node: ppc64le
+
+annotations: {}
+
+tolerations: []
+  # - operator: Exists
+
+affinity: {}
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+## Specify if a Pod Security Policy for filebeat must be created
+## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+##
+podSecurityPolicy:
+  enabled: False
+  annotations: {}
+    ## Specify pod annotations
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+    ##
+    # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'


### PR DESCRIPTION
Hi,

We have raised PR to merge the ibm-filebeat-dev helm chart (open source).
This chart have fixes for cv lint version 1.2.6
We have validated chart on ICP 3.1.1 and it works on ppc64le.
Please review and let us know if any changes are needed.

Thanks,
Vikas Kumar