### PR TITLE
Added helm chart for ibm-magic-namespace-dev for ppc64le

### DIFF
--- a/stable/ibm-magic-namespace-dev/.helmignore
+++ b/stable/ibm-magic-namespace-dev/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/ibm-magic-namespace-dev/Chart.yaml
+++ b/stable/ibm-magic-namespace-dev/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+name: ibm-magic-namespace-dev
+version: 0.3.0
+appVersion: 2.9.1
+home: https://github.com/kubernetes/charts/tree/master/stable/magic-namespace
+description: Elegantly enables a Tiller per namespace in RBAC-enabled clusters
+maintainers:
+- name: krancour
+  email: kent.rancourt@microsoft.com
+keywords:
+- magic-namespace
+- Limited
+- ppc64le
+- Tools
+- ICP
+- Beta
+tillerVersion: '>=2.7.2'
+kubeVersion: ">=1.7.0"
+sources:
+- https://github.com/helm/charts/tree/master/stable/magic-namespace
+

--- a/stable/ibm-magic-namespace-dev/LICENSE
+++ b/stable/ibm-magic-namespace-dev/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The Helm Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/stable/ibm-magic-namespace-dev/README.md
+++ b/stable/ibm-magic-namespace-dev/README.md
@@ -1,0 +1,179 @@
+# Magic Namespace
+
+**Magic Namespace** provides an easy, comprehensive option for cluster operators
+to manage namespaces and observe good security practices in _multi-tenant,
+RBAC-enabled_ Kubernetes clusters.
+
+## Introduction
+
+So you've got a multi-tenant cluster? Let's assume your cluster is RBAC-enabled.
+If it isn't, _go fix that first_. You're playing with fire. Until you fix that,
+you don't need Magic Namespace. Go fix it. We'll wait...
+
+In a multi-tenant cluster, a cluster operator (someone with full, unrestricted
+privileges across the entire cluster), will manage users, groups, service
+accounts, roles, and user/group bindings to roles-- all to either permit or
+prevent subjects from performing certain actions in different namespaces.
+
+A common paradigm that has emerged is that _teams_ are given their own namespace
+and some degree of latitude to administer that namespace, whilst not being
+permitted to perform actions on _other teams'_ namespaces.
+
+Now bring Helm/Tiller into the equation. In an RBAC-enabled cluster, Tiller is
+so often granted the `cluster-admin` role-- which gives it "root" access to the
+entire cluster. While such a Tiller may be suitable for use by a cluster
+operator, it's _not_ suitable for use by other teams, as it presents them with
+an easy avenue for escalating their privileges.
+
+To compensate for this, a pattern that has emmerged to complement the
+namespace-per-team pattern is the _tiller-per-namespace_ pattern. This has been
+widely adopted in multi-tenant, RBAC-enabled clusters. Until now, cluster
+operators have tended to create their own bespoke scripts for performing all
+requisite setup to implement these patterns.
+
+Magic Namespace takes the pain out of this setup. It offers cluster operators an
+easy, comprehensive avenue for using _their_ Tiller to manage namespaces,
+service accounts, _other Tillers_, and role bindings for their consituent
+teams. Magic Namespace permits cluster operators to manage all of this using
+familiar Helm-based workflows.
+
+## How it Works
+
+By default, Magic Namespace creates a service account for Tiller in the
+designated namespace and binds it to the `admin` role for that namespace. It
+also creates a deployment that utilizes this service account. This can be
+disabled or configured further, but the default behavior is sensible. In fact,
+the defaults _closes_ a variety of known Tiller-based attack vectors.
+
+Magic Namespace also offers cluster operators to define additional service
+accounts and role bindings for use within the namespace. _Typically, it would
+be a good idea to define at least one role binding that grants a user or group
+administrative privileges in the namespace._ Absent this, the namespace's own
+Tiller will function, but no user (other than the cluster operator) will be
+capable of interacting with it via Helm.
+
+## Prerequisites
+
+- A Kubernetes cluster with RBAC enabled
+
+## Resources Required
+The chart deploys pods consuming minimum resources as specified in the resources configuration parameter (default: Memory: 200Mi, CPU: 100m)
+
+## PodSecurityPolicy Requirements
+This chart requires a PodSecurityPolicy to be bound to the target namespace prior to installation. Choose predefined ibm-restricted-psp PodSecurityPolicy.
+
+## Chart Details
+
+## Limitations
+
+## Installing the Chart
+
+To install the chart to create the `foo` namespace (if it doesn't already exist)
+and useful resources (Tiller, service accounts, etc.) within that namespace:
+
+```bash
+$ helm install stable/magic-namespace --name foo --namespace foo
+```
+
+Typically, you will want to bind at least one user or group to the `admin` role
+in this namespace. Here are steps to follow:
+
+First, make a copy of the default `values.yaml`:
+
+```bash
+$ helm inspect values stable/magic-namespace > ~/my-values.yaml
+```
+
+Edit `~/my-values.yaml` accordingly. Here is a sample role binding:
+
+```
+...
+
+roleBindings:
+- name: admin-group-admin
+  role:
+    ## Valid values are "Role" or "ClusterRole"
+    kind: ClusterRole
+    name: admin
+  subject:
+    ## Valid values are "User", "Group", or "ServiceAccount"
+    kind: Group
+    name: <group>
+
+...
+```
+
+Deploy as follows:
+
+```bash
+$ helm install stable/magic-namespace \
+  --name foo \
+  --namespace foo \
+  --values ~/my-values.yaml
+```
+
+## Uninstalling the Chart
+
+Deleting a release of a Magic Namespace will _not_ delete the namespace,
+unless you have used the optional ```namespace``` setting. It will
+only delete the Tiller, service accounts, role bindings, etc. from that
+namespace. This is actually desirable behavior, as anything the team has
+deployed within that namespace is likely to be unaffected, though further
+deployments to and management of that namespace will not be possible by anyone
+other than the cluster operator.
+
+If you have used the ```namespace``` setting, deleting the release will cleanup
+all releases deployed with the tiller in the Magic Namespace, along with the
+namespace.  If other tillers, such as the one in ```kube-system``` have
+deployed charts into the Magic Namespace, they will get orphaned when the namespace is
+removed, but they can still be removed with the standard ```helm delete <name> --purge``` command.
+
+```bash
+$ helm delete foo --purge
+```
+
+## Configuration
+
+The following table lists the most common, useful, and interesting configuration
+parameters of the Magic Namespace chart and their default values. Please
+reference the default `values.yaml` to understand further options.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `tiller.enabled` | Whether to include a Tiller in the namespace | `true` |
+| `tiller.replicaCount` | The number of Tiller replicas to run | `1` |
+| `tiller.image.repository` | The Docker image to use for Tiller, minus version/label | `gcr.io/kubernetes-helm/tiller` |
+| `tiller.image.tag` | The specific version/label of the Docker image used for Tiller | `v2.8.1` |
+| `tiller.image.pullPolicy` | The pull policy to utilize when pulling Tiller images from a Docker repsoitory | `IfNotPresent` |
+| `tiller.maxHistory` | The maximum number of releases Tiller should remember. A value of `0` is interpreted as no limit. | `0` |
+| `tiller.role.type` | Identify the kind of role (`Role` or `ClusterRole`) that will be referenced in the role binding for Tiller's service account. There is seldom any reason to override this. | `ClusterRole` |
+| `tiller.role.type` | Identify the name of the `Role` or `ClusterRole` that will be referenced in the role binding for Tiller's service account. There is seldom any reason to override this. | `admin` |
+| `tiller.includeService` | This deploys a service resource for Tiller. This is not generally needed. Please understand the security implications of this before overriding the default. | `false` |
+| `tiller.onlyListenOnLocalhost` | This prevents Tiller from binding to `0.0.0.0`. This is generally advisable to close known Tiller-based attack vectors. Please understand the security implications of this before overriding the default. | `true` |
+| `serviceAccounts` | An optional array of names of additional service account to create | `nil` |
+| `roleBindings` | An optional array of objects that define role bindings | `nil` |
+| `roleBindings[n].role.kind` | Identify the kind of role (`Role` or `ClusterRole`) to be used in the role binding | |
+| `roleBindings[n].role.name` | Identify the name of the role to be used in the role binding | |
+| `roleBindings[n].subject.kind` | Identify the kind of subject (`User`, `Group`, or `ServiceAccount` ) to be used in the role binding | |
+| `roleBindings[n].subject.name` | Identify the name of the subject to be used in the role binding | |
+| `namespace` | Specify a namespace to be created and used, overriding the one on the command line | |
+| `namespaceAttributes.annotations` | Specify annotations to be attached to the namespace | |
+| `namespaceAttributes.lables` | Specify labels to be attached to the namespace | |
+
+## Support
+
+The helm charts are provided "as-is" and without warranty of any kind.
+
+All helm charts and packages are supported through standard open source forums and helm charts are updated on a best effort basis.
+
+Any issues found can be reported through the links below, and fixes may be proposed/submitted using standard git issues as noted below.
+
+[Submit issue to Helm Chart] ( https://github.com/ppc64le/charts/issues )
+
+[Submit issue to tiller docker image]  ( https://hub.docker.com/r/ibmcom/tiller-ppc64le )
+
+[Submit issue to helm open source community] ( https://github.com/helm/helm/issues )
+
+## Note
+
+This chart is validated on ppc64le.

--- a/stable/ibm-magic-namespace-dev/RELEASENOTES.md
+++ b/stable/ibm-magic-namespace-dev/RELEASENOTES.md
@@ -1,0 +1,24 @@
+# Release Notes
+
+## What's new in Chart Version 1.0
+
+- Initial Release
+
+## Fixes
+
+- No fixes
+
+## Breaking Changes
+
+## Documentation
+
+## Prerequisites
+
+- No changes
+
+## Version History
+
+| Chart | Date | Kubernetes Version Required | Breaking Changes | Details |
+| ----- | ---- | --------------------------- | ---------------- | ------- |
+| 0.1.0 | September 12, 2018 | >= 1.7 | None | Initial version |
+

--- a/stable/ibm-magic-namespace-dev/templates/NOTES.txt
+++ b/stable/ibm-magic-namespace-dev/templates/NOTES.txt
@@ -1,0 +1,25 @@
+The namespace "{{ .Release.Namespace }}" has been created if it didn't already exist.
+
+{{ if or .Values.tiller.enabled .Values.serviceAccounts -}}
+The following service accounts have been created in the namespace:
+{{ if .Values.tiller.enabled }}
+  - tiller
+{{- end }}
+{{- range .Values.serviceAccounts }}
+  - {{ . }}
+{{- end }}
+{{ end }}
+{{ if or .Values.tiller.enabled .Values.roleBindings -}}
+The following role bindings have been created in the namespace:
+{{ if .Values.tiller.enabled }}
+  - ServiceAccount[tiller] --> {{ .Values.tiller.role.kind }}[{{ .Values.tiller.role.name }}]
+{{- end }}
+{{- range .Values.roleBindings }}
+  - {{ .subject.kind }}[{{ .subject.name }}] --> {{ .role.kind }}[{{ .role.name }}]
+{{- end }}
+{{ end }}
+{{ if .Values.tiller.enabled -}}
+Utilize the Tiller in your new namespace like so:
+
+  $ helm <command> --tiller-namespace {{ .Release.Namespace }}
+{{- end }}

--- a/stable/ibm-magic-namespace-dev/templates/_affinity.tpl
+++ b/stable/ibm-magic-namespace-dev/templates/_affinity.tpl
@@ -1,0 +1,18 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+#https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ .Values.tiller.node }}
+{{- end }}
+

--- a/stable/ibm-magic-namespace-dev/templates/_helpers.tpl
+++ b/stable/ibm-magic-namespace-dev/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "magic-namespace.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "magic-namespace.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "magic-namespace.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/ibm-magic-namespace-dev/templates/namespace.yaml
+++ b/stable/ibm-magic-namespace-dev/templates/namespace.yaml
@@ -1,0 +1,16 @@
+{{- if hasKey .Values "namespace" -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  {{- if hasKey .Values "namespaceAttributes" }}
+{{ toYaml .Values.namespaceAttributes | indent 2 }}
+  {{ end -}}
+{{- end }}
+  labels:
+    app: helm
+    name: tiller
+    chart: {{ template "magic-namespace.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+

--- a/stable/ibm-magic-namespace-dev/templates/rolebindings.yaml
+++ b/stable/ibm-magic-namespace-dev/templates/rolebindings.yaml
@@ -1,0 +1,23 @@
+{{- $values := .Values }}
+{{- range .Values.roleBindings }}
+#---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .name }}
+  {{- if hasKey $values "namespace" }}
+  namespace: {{ $values.namespace }}
+  {{- end }}
+  labels:
+    app: helm
+    chart: {{ template "magic-namespace.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ .role.kind }}
+  name: {{ .role.name }}
+subjects:
+- kind: {{ .subject.kind }}
+  name: {{ .subject.name }}
+{{- end }}

--- a/stable/ibm-magic-namespace-dev/templates/serviceaccounts.yaml
+++ b/stable/ibm-magic-namespace-dev/templates/serviceaccounts.yaml
@@ -1,0 +1,16 @@
+{{- $values := .Values }}
+{{- range .Values.serviceAccounts }}
+#---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ . }}
+  {{- if hasKey $values "namespace" }}
+  namespace: {{ $values.namespace }}
+  {{- end }}
+  labels:
+    app: helm
+    chart: {{ template "magic-namespace.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+{{- end }}

--- a/stable/ibm-magic-namespace-dev/templates/tiller-deployment.yaml
+++ b/stable/ibm-magic-namespace-dev/templates/tiller-deployment.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.tiller.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: tiller-deploy
+  {{- if hasKey .Values "namespace" }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
+  labels:
+    app: helm
+    name: tiller
+    chart: {{ template "magic-namespace.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.tiller.replicaCount }}
+  selector:
+    matchLabels:
+      app: helm
+      name: tiller
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: helm
+        name: tiller
+        chart: {{ template "magic-namespace.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      annotations:
+        productName: magic-namespace
+        productID: magic-namespace_{{ .Chart.Version }}
+        productVersion: {{ .Chart.Version }}
+    spec:
+      serviceAccountName: tiller
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.tiller.image.repository }}:{{ .Values.tiller.image.tag }}"
+          imagePullPolicy: {{ .Values.tiller.image.pullPolicy }}
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+             drop:
+              - ALL
+          env:
+          - name: TILLER_NAMESPACE
+            {{- if hasKey .Values "namespace" }}
+            value: {{ .Values.namespace }}
+            {{- else }}
+            value: {{ .Release.Namespace }}
+            {{- end }}
+          - name: TILLER_HISTORY_MAX
+            value: {{ quote .Values.tiller.maxHistory }}
+          {{- if .Values.tiller.onlyListenOnLocalhost }}
+          command: ["/tiller"]
+          args: ["--listen=127.0.0.1:44134"]
+          {{- else }}
+          ports:
+          - containerPort: 44134
+            name: tiller
+            protocol: TCP
+          - containerPort: 44135
+            name: http
+            protocol: TCP
+          {{- end }}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /liveness
+              port: 44135
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readiness
+              port: 44135
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+{{ toYaml .Values.tiller.resources | indent 12 }}
+    {{- with .Values.tiller.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tiller.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- if .Values.tiller.node }}
+      affinity:
+        {{- include "nodeaffinity" . | indent 6 }}
+{{- end }}
+    {{- with .Values.tiller.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/stable/ibm-magic-namespace-dev/templates/tiller-rolebinding.yaml
+++ b/stable/ibm-magic-namespace-dev/templates/tiller-rolebinding.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.tiller.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tiller-{{ .Values.tiller.role.name }}
+  {{- if hasKey .Values "namespace" }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
+  labels:
+    app: helm
+    name: tiller
+    chart: {{ template "magic-namespace.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ .Values.tiller.role.type }}
+  name: {{ .Values.tiller.role.name }}
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  {{- if hasKey .Values "namespace" }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+
+{{- end }}

--- a/stable/ibm-magic-namespace-dev/templates/tiller-service.yaml
+++ b/stable/ibm-magic-namespace-dev/templates/tiller-service.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.tiller.enabled .Values.tiller.includeService }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: tiller-deploy
+  {{- if hasKey .Values "namespace" }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
+  labels:
+    app: helm
+    name: tiller
+    chart: {{ template "magic-namespace.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  selector:
+    app: helm
+    name: tiller
+  ports:
+  - name: tiller
+    port: 44134
+    protocol: TCP
+    targetPort: tiller
+{{- end }}

--- a/stable/ibm-magic-namespace-dev/templates/tiller-serviceaccount.yaml
+++ b/stable/ibm-magic-namespace-dev/templates/tiller-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.tiller.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  {{- if hasKey .Values "namespace" }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
+  labels:
+    app: helm
+    name: tiller
+    chart: {{ template "magic-namespace.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/stable/ibm-magic-namespace-dev/values-metadata.yaml
+++ b/stable/ibm-magic-namespace-dev/values-metadata.yaml
@@ -1,0 +1,159 @@
+namespace:
+  __metadata:
+    name: "namespace"
+    label: "Namespace"
+    description: "Specify a namespace to be created and used, overriding the one on the command line"
+    type: "string"
+    immutable: false
+    required: false
+
+tiller:
+  __metadata:
+    label: "Tiller Settings"
+    description: "Settings for including Tiller in a namespace"
+  enabled:
+    __metadata:
+      name: "enabled"
+      label: "Enable Tiller"
+      description: "Whether to include a Tiller in the namespace"
+      type: "boolean"
+      immutable: false
+      required: true
+  replicaCount:
+    __metadata:
+      name: "replicaCount"
+      label: "Replica Count"
+      description: "Number of replicas of deployment needed to be created"
+      type: "number"
+      immutable: false
+      required: true
+  image:
+    repository:
+      __metadata:
+        name: "repository"
+        label: "Repository"
+        description: "The Docker image to use for Tiller, minus version/label"
+        type: "string"
+        immutable: false
+        required: true
+    tag:
+      __metadata:
+        name: "tag"
+        label: "Tag"
+        description: "The specific version/label of the Docker image used for Tiller"
+        type: "string"
+        immutable: false
+        required: true
+    pullPolicy:
+      __metadata:
+        name: "pullPolicy"
+        label: "Docker image pull policy"
+        description: "The pull policy to utilize when pulling Tiller images from a Docker repsoitory"
+        type: "string"
+        immutable: true
+        required: true
+        options:
+        - label: "Always"
+          value: "Always"
+        - label: "Never"
+          value: "Never"
+        - label: "IfNotPresent"
+          value: "IfNotPresent"
+
+  maxHistory:
+    __metadata:
+      name: "maxHistory"
+      label: "Max release count"
+      description: "The maximum number of releases Tiller should remember. A value of 0 is interpreted as no limit."
+      type: "number"
+      immutable: false
+      required: true
+
+  role:
+    type:
+      __metadata:
+        name: "type"
+        label: "Type"
+        description: "Identify the kind of role that will be referenced in the role binding for Tiller's service account."
+        type: "string"
+        immutable: true
+        required: true
+        options:
+        - label: "Role"
+          value: "Role"
+        - label: "ClusterRole"
+          value: "ClusterRole"
+    name:
+      __metadata:
+        name: "name"
+        label: "Name"
+        description: "Identify the name of the Role or ClusterRole that will be referenced in the role binding for Tiller's service account."
+        type: "string"
+        immutable: false
+        required: true
+    kind:
+      __metadata:
+        name: "kind"
+        label: "Kind"
+        description: "Identify the kind of role that will be referenced in the role binding for Tiller's service account."
+        type: "string"
+        immutable: false
+        required: false
+
+  includeService:
+    __metadata:
+      name: "includeService"
+      label: "Service Resource"
+      description: "This deploys a service resource for Tiller."
+      type: "boolean"
+      immutable: false
+      required: true
+
+  onlyListenOnLocalhost:
+    __metadata:
+      name: "onlyListenOnLocalhost"
+      label: "Bind Localhost"
+      description: "This prevents Tiller from binding to 0.0.0.0. This is generally advisable to close known Tiller-based attack vectors."
+      type: "boolean"
+      immutable: false
+      required: true
+
+  tolerations:
+    __metadata:
+      name: "tolerations"
+      label: "Tolerations"
+      description: "Toleration labels for pod assignment, e.g. [{\"key\": \"key\", \"operator\":\"Equal\", \"value\": \"value\", \"effect\":\"NoSchedule\"}]"
+      type: "string"
+      immutable: false
+      required: true
+
+  node:
+   __metadata:
+     name: "Node"
+     label: "Node Preference"
+     description: "Select node architecture to deploy chart on"
+     type: "string"
+     immutable: false
+     required: true
+     options:
+     - label: "ppc64le"
+       value: "ppc64le"
+
+serviceAccounts:
+  __metadata:
+    name: "serviceAccounts"
+    label: "Additional serviceAccounts"
+    description: "An optional array of names of additional service account to create"
+    type: "string"
+    immutable: false
+    required: false
+
+roleBindings:
+  __metadata:
+    name: "roleBindings"
+    label: "RoleBindings"
+    description: "An optional array of objects that define role bindings"
+    type: "string"
+    immutable: false
+    required: false
+

--- a/stable/ibm-magic-namespace-dev/values.yaml
+++ b/stable/ibm-magic-namespace-dev/values.yaml
@@ -1,7 +1,7 @@
 ## Default values for magic-namespace
 
 # Uncomment and set to override the namespace that will be created.
-namespace: magic
+# namespace: magic
 
 # Extra namespace attributes
 namespaceAttributes: 

--- a/stable/ibm-magic-namespace-dev/values.yaml
+++ b/stable/ibm-magic-namespace-dev/values.yaml
@@ -1,0 +1,86 @@
+## Default values for magic-namespace
+
+# Uncomment and set to override the namespace that will be created.
+namespace: magic
+
+# Extra namespace attributes
+namespaceAttributes: 
+  # Labels to be added to the namespace definition
+  labels: {}
+
+  # Annotations to be added to the namespace definition
+  annotations: {}
+
+tiller:
+  enabled: true
+
+  replicaCount: 1
+
+  image:
+    #repository: gcr.io/kubernetes-helm/tiller
+    repository: ibmcom/tiller-ppc64le
+    tag: v2.9.1-icp-3.1.1
+    pullPolicy: IfNotPresent
+
+  maxHistory: 0
+
+  ## The following options specify the Role or ClusterRole to assign to the
+  ## tiller service account. The ClusterRole "admin" is usually pre-defined in
+  ## RBAC-enabled clusters and will allow administration of a namespace by
+  ## whatever users or ServiceAccounts are bound to it in that same namespace.
+  ## THERE IS SELDOM ANY REASON TO OVERRIDE THIS!!!
+  role:
+    ## Valid values are "Role" or "ClusterRole"
+    type: ClusterRole
+    name: admin
+    kind: ""
+
+  ## Security options. The default values close known attack vectors.
+  ## ALTER THESE AT YOUR OWN RISK!!!!
+
+  ## Note that these tight restrictions do NOT impede normal use of Helm. Helm
+  ## is always usable with any Tiller as long as the Helm user has permission to
+  ## tunnel into pods in that Tiller's namespace.
+  ## (Helm does this automatically.)
+
+  ## Specify whether to include a service of type ClusterIP for Tiller
+  includeService: false
+
+  ## Specify whether Tiller pods should listen to 0.0.0.0 or just localhost
+  onlyListenOnLocalhost: true
+
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  nodeSelector: {}
+  node: "ppc64le"
+
+  tolerations: []
+
+  affinity: {}
+
+## Optional additional ServiceAccounts
+serviceAccounts:
+- some-service-account
+
+## Optional additional RoleBindings. It is a good idea to specify at least one
+## to grant administrative permissions to a user or group.
+roleBindings: 
+- name: admin-group-admin
+  role:
+#     ## Valid values are "Role" or "ClusterRole"
+    kind: ClusterRole
+    name: admin
+  subject:
+#     ## Valid values are "User", "Group", or "ServiceAccount"
+    kind: Group
+    name: <group>

--- a/stable/ibm-magic-namespace-dev/values.yaml
+++ b/stable/ibm-magic-namespace-dev/values.yaml
@@ -1,7 +1,7 @@
 ## Default values for magic-namespace
 
 # Uncomment and set to override the namespace that will be created.
-# namespace: magic
+# namespace: default
 
 # Extra namespace attributes
 namespaceAttributes: 


### PR DESCRIPTION
Hi,

We have raised PR to merge the ibm-magic-namespace-dev helm chart (open source).
This chart have fixes for cv lint version 1.2.6
We have validated chart on ICP 3.1.1 and it works on ppc64le.
Please review and let us know if any changes are needed.

Thanks,
Vikas Kumar