### PR TITLE
Add configurable sshd port for glusterfs pod

### DIFF
--- a/stable/ibm-glusterfs/templates/_sch-chart-config.tpl
+++ b/stable/ibm-glusterfs/templates/_sch-chart-config.tpl
@@ -47,4 +47,6 @@ sch:
         name: "storageclass-job"
       sccm:
         name: "storageclass-cm"
+      glustersshdcm:
+        name: "gluster-sshd-cm"        
 {{- end -}}

--- a/stable/ibm-glusterfs/templates/gluster-sshd-cm.yaml
+++ b/stable/ibm-glusterfs/templates/gluster-sshd-cm.yaml
@@ -1,0 +1,36 @@
+###############################################################################
+# Licensed Materials - Property of IBM
+# 5737-E67
+# (C) Copyright IBM Corporation 2016, 2018 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure
+# restricted by GSA ADP Schedule Contract with IBM Corp.
+################################################################################
+
+{{- include "sch.config.init" (list . "glusterfs.sch.chart.config.values") }}
+{{- $glustersshdcmName :=  .sch.chart.components.glustersshdcm.name }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sch.names.fullCompName" (list . $glustersshdcmName) }}
+  namespace: {{ .Release.Namespace }}
+data:
+
+  sshd_config: |
+    Port {{ .Values.gluster.sshd_port }}
+    HostKey /etc/ssh/ssh_host_rsa_key
+    HostKey /etc/ssh/ssh_host_ecdsa_key
+    HostKey /etc/ssh/ssh_host_ed25519_key
+    SyslogFacility AUTHPRIV
+    AuthorizedKeysFile	.ssh/authorized_keys
+    PasswordAuthentication yes
+    ChallengeResponseAuthentication no
+    GSSAPIAuthentication yes
+    GSSAPICleanupCredentials no
+    UsePAM yes
+    X11Forwarding yes
+    AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+    AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+    AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
+    AcceptEnv XMODIFIERS
+    Subsystem	sftp	/usr/libexec/openssh/sftp-server

--- a/stable/ibm-glusterfs/templates/glusterfs-daemonset.yaml
+++ b/stable/ibm-glusterfs/templates/glusterfs-daemonset.yaml
@@ -8,6 +8,7 @@
 
 {{- include "sch.config.init" (list . "glusterfs.sch.chart.config.values") }}
 {{- $glusterfsdsName :=  .sch.chart.components.glusterfsds.name }}
+{{- $glustersshdcmName :=  .sch.chart.components.glustersshdcm.name }}
 
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -76,6 +77,9 @@ spec:
               mountPath: "/dev"
             - name: glusterfs-cgroup
               mountPath: "/sys/fs/cgroup"
+            - name: sshd-config
+              mountPath: "/etc/ssh/sshd_config"
+              subPath: "sshd_config"
           securityContext:
             capabilities: {}
             privileged: true
@@ -120,6 +124,13 @@ spec:
         - name: glusterfs-cgroup
           hostPath:
             path: "/sys/fs/cgroup"
+        - name: sshd-config
+          configMap:
+            name: {{ include "sch.names.fullCompName" (list . $glustersshdcmName) }}
+            defaultMode: 0600
+            items:
+            - key: sshd_config
+              path: sshd_config           
       nodeSelector:
         {{ .Values.nodeSelector.key }}: {{ .Values.nodeSelector.value }}
       affinity:

--- a/stable/ibm-glusterfs/templates/precheck-configmap.yaml
+++ b/stable/ibm-glusterfs/templates/precheck-configmap.yaml
@@ -42,7 +42,7 @@ data:
 
     precheck_cm = {{ include "sch.names.fullCompName" (list . $precheckresultscmName) | quote }}
 
-    glusterfs_ports = [2222, 24007, 24008]
+    glusterfs_ports = [ {{ .Values.gluster.sshd_port }} , 24007, 24008]
     glusterfs_client_port_start = 49152
     glusterfs_client_port_end = 49251
 

--- a/stable/ibm-glusterfs/values-metadata.yaml
+++ b/stable/ibm-glusterfs/values-metadata.yaml
@@ -198,6 +198,14 @@ gluster:
           description: "The memory limit"
           type: "string"
           required: true
+  sshd_port:
+    __metadata:
+      name: "sshd_port"
+      label: "Gluster SSHD Port"
+      description: "SSH Daemon port for Gluster Pod"
+      type: "number"
+      immutable: false
+      required: true
 
 ###############################################################################
 ## Heketi Configuration Parameters

--- a/stable/ibm-glusterfs/values.yaml
+++ b/stable/ibm-glusterfs/values.yaml
@@ -50,6 +50,7 @@ gluster:
     limits:
       cpu: "1000m"
       memory: "1Gi"
+  sshd_port: 2222
 
 ###############################################################################
 ## Heketi Configuration Parameters


### PR DESCRIPTION
GlusterFS DeploymentSet use sshd port 2222 that may conflict with other application port. This pull request added variable `gluster.sshd_port` to allow configurable sshd port for GlusterFS Pods.