### PR TITLE
changes in istio tracing jaeger ingress chart

### DIFF
--- a/stable/ibm-istio/charts/tracing/templates/ingress-jaeger.yaml
+++ b/stable/ibm-istio/charts/tracing/templates/ingress-jaeger.yaml
@@ -10,13 +10,13 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    {{- range $key, $value := .Values.jaeger.ingress.annotations }}
+    {{- range $key, $value := .Values.tracing.jaeger.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
 {{- if .Values.tracing.jaeger.ingress.hosts }}
-    {{- range $host := .Values.jaeger.ingress.hosts }}
+    {{- range $host := .Values.tracing.jaeger.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
@@ -34,8 +34,8 @@ spec:
               serviceName: jaeger-query
               servicePort: 16686
 {{- end }}
-  {{- if .Values.jaeger.ingress.tls }}
+  {{- if .Values.tracing.jaeger.ingress.tls }}
   tls:
-{{ toYaml .Values.jaeger.ingress.tls | indent 4 }}
+{{ toYaml .Values.tracing.jaeger.ingress.tls | indent 4 }}
   {{- end -}}
 {{- end -}}

--- a/stable/ibm-istio/charts/tracing/templates/ingress-jaeger.yaml
+++ b/stable/ibm-istio/charts/tracing/templates/ingress-jaeger.yaml
@@ -1,4 +1,4 @@
-{{ if (.Values.jaeger.ingress.enabled) and eq .Values.provider "jaeger" }}
+{{ if (.Values.tracing.jaeger.ingress.enabled) and eq .Values.provider "jaeger" }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -15,7 +15,7 @@ metadata:
     {{- end }}
 spec:
   rules:
-{{- if .Values.ingress.hosts }}
+{{- if .Values.tracing.jaeger.ingress.hosts }}
     {{- range $host := .Values.jaeger.ingress.hosts }}
     - host: {{ $host }}
       http:


### PR DESCRIPTION
Hi guys,

# Issue
While I was working with `ibm-istio` chart, I tried to enable ingress for `jeager` but no ingress was created for it. After looking at the `jaeger ingress chart` I found some issue that I tried to resolve in this PR. 

# Description

* Manifest description:
```yaml
apiVersion: flux.weave.works/v1beta1
kind: HelmRelease
metadata:
  name: istio
  namespace: istio-system
spec:
  releaseName: istio
  chart:
    repository: https://raw.githubusercontent.com/IBM/charts/master/repo/stable
    name: ibm-istio
    version: 1.0.5
  values:
    global:
      enableTracing: true
    tracing:
      enabled: true
      jaeger:
        ingress:
          enabled: true
    pilot:
      traceSampling: 100
```



* Issue in the documentation:

  * the jaeger keyword comes under the tracing key but according to this chart `jaeger` is an independent key.

  * it checks host addresses under this `.Values.ingress.hosts ` key instead of `.Values.tracing.jaeger.ingress.hosts `

```yaml
`{{ if (.Values.jaeger.ingress.enabled) and eq .Values.provider "jaeger" }}`
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: jaeger-query
  namespace: {{ .Release.Namespace }}
  labels:
    app: jaeger
    chart: {{ template "tracing.chart" . }}
    heritage: {{ .Release.Service }}
    release: {{ .Release.Name }}
  annotations:
    {{- range $key, $value := .Values.jaeger.ingress.annotations }}
      {{ $key }}: {{ $value | quote }}
    {{- end }}
spec:
  rules:
{{- if .Values.ingress.hosts }}
    {{- range $host := .Values.jaeger.ingress.hosts }}
    - host: {{ $host }}
      http:
        paths:
          - path: {{ if .Values.jaeger.contextPath }} {{ .Values.jaeger.contextPath }} {{ else }} / {{ end }}
            backend:
              serviceName: jaeger-query
              servicePort: 16686
```


Kindly have a look at the changes I have made this PR, so that it can be confirmed that whether the issue is on my side or chart have some issues. Thank you.

