### PR TITLE
Add crd-install in CustomResourceDefinition

### DIFF
--- a/community/knative/all-crds.yaml
+++ b/community/knative/all-crds.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     knative.dev/crd-install: 'true'
   name: builds.build.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Succeeded")].status
@@ -36,6 +38,8 @@ metadata:
   labels:
     knative.dev/crd-install: 'true'
   name: buildtemplates.build.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .metadata.creationTimestamp
@@ -59,6 +63,8 @@ metadata:
   labels:
     knative.dev/crd-install: 'true'
   name: clusterbuildtemplates.build.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .metadata.creationTimestamp
@@ -80,6 +86,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: caching.internal.knative.dev
   names:
@@ -103,6 +111,8 @@ metadata:
   labels:
     knative.dev/crd-install: 'true'
   name: brokers.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -166,6 +176,8 @@ metadata:
   labels:
     knative.dev/crd-install: 'true'
   name: channels.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -258,6 +270,8 @@ metadata:
   labels:
     knative.dev/crd-install: 'true'
   name: clusterchannelprovisioners.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -292,6 +306,8 @@ metadata:
   labels:
     knative.dev/crd-install: 'true'
   name: subscriptions.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -392,6 +408,8 @@ metadata:
   labels:
     knative.dev/crd-install: 'true'
   name: triggers.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -474,6 +492,8 @@ metadata:
     eventing.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
   name: awssqssources.sources.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: sources.eventing.knative.dev
   names:
@@ -543,6 +563,8 @@ metadata:
     eventing.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
   name: containersources.sources.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: sources.eventing.knative.dev
   names:
@@ -617,6 +639,8 @@ metadata:
     eventing.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
   name: cronjobsources.sources.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: sources.eventing.knative.dev
   names:
@@ -686,6 +710,8 @@ metadata:
     eventing.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
   name: githubsources.sources.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: sources.eventing.knative.dev
   names:
@@ -808,6 +834,8 @@ metadata:
     eventing.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
   name: kuberneteseventsources.sources.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: sources.eventing.knative.dev
   names:
@@ -876,6 +904,8 @@ metadata:
     eventing.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
   name: camelsources.sources.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: sources.eventing.knative.dev
   names:
@@ -954,6 +984,8 @@ metadata:
     eventing.knative.dev/source: 'true'
     knative.dev/crd-install: 'true'
   name: gcppubsubsources.sources.eventing.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: sources.eventing.knative.dev
   names:
@@ -1023,6 +1055,8 @@ metadata:
     knative.dev/crd-install: 'true'
     serving.knative.dev/release: devel
   name: certificates.networking.internal.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -1054,6 +1088,8 @@ metadata:
     knative.dev/crd-install: 'true'
     serving.knative.dev/release: devel
   name: clusteringresses.networking.internal.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=='Ready')].status
@@ -1083,6 +1119,8 @@ metadata:
     knative.dev/crd-install: 'true'
     serving.knative.dev/release: devel
   name: configurations.serving.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.latestCreatedRevisionName
@@ -1121,6 +1159,8 @@ metadata:
     knative.dev/crd-install: 'true'
     serving.knative.dev/release: devel
   name: podautoscalers.autoscaling.internal.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=='Ready')].status
@@ -1152,6 +1192,8 @@ metadata:
     knative.dev/crd-install: 'true'
     serving.knative.dev/release: devel
   name: revisions.serving.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.serviceName
@@ -1189,6 +1231,8 @@ metadata:
     knative.dev/crd-install: 'true'
     serving.knative.dev/release: devel
   name: routes.serving.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.domain
@@ -1223,6 +1267,8 @@ metadata:
     knative.dev/crd-install: 'true'
     serving.knative.dev/release: devel
   name: services.serving.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.domain
@@ -1264,6 +1310,8 @@ metadata:
     knative.dev/crd-install: 'true'
     serving.knative.dev/release: devel
   name: serverlessservices.networking.internal.knative.dev
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: networking.internal.knative.dev
   names:


### PR DESCRIPTION
crd-install: Adds CRD resources before any other checks are run. We need this annotation
If we don't add this annotation, the error will happen when we use the chart install.

```
[root@julie-3 community]# helm install ./knative --name knative  --tls
Error: validation failed: [unable to recognize "": no matches for kind "Service" in version "serving.knative.dev/v1alpha1", unable to recognize "": no matches for kind "ClusterChannelProvisioner" in version "eventing.knative.dev/v1alpha1", unable to recognize "": no matches for kind "ClusterChannelProvisioner" in version "eventing.knative.dev/v1alpha1", unable to recognize "": no matches for kind "Image" in version "caching.internal.knative.dev/v1alpha1", unable to recognize "": no matches for kind "Image" in version "caching.internal.knative.dev/v1alpha1", unable to recognize "": no matches for kind "Image" in version "caching.internal.knative.dev/v1alpha1", unable to recognize "": no matches for kind "Image" in version "caching.internal.knative.dev/v1alpha1", unable to
recognize "": no matches for kind "Image" in version "caching.internal.knative.dev/v1alpha1"]
```

@neeraj-laad