### PR TITLE
Fixed typo at truststore cert search

### DIFF
--- a/stable/ibm-ace-server-dev/ibm_cloud_pak/pak_extensions/pre-install/generateSecrets.sh
+++ b/stable/ibm-ace-server-dev/ibm_cloud_pak/pak_extensions/pre-install/generateSecrets.sh
@@ -63,7 +63,7 @@ if [ -s ./truststorePassword.txt ]; then
   SECRET_ARGS="${SECRET_ARGS} --from-file=truststorePassword=./truststorePassword.txt"
 fi
 
-for certfile in `ls ./truststore-*.crt`; do
+for certfile in `ls ./truststoreCert-*.crt`; do
   if [ -s "${certfile}" ]; then
     if [ ! -s ./truststorePassword.txt ]; then
       echo "No truststore password defined"
@@ -71,7 +71,7 @@ for certfile in `ls ./truststore-*.crt`; do
     fi
 
     filename=$(basename ${certfile})
-    alias=$(echo ${filename} | sed -r 's/truststore-(.*)\.crt$/\1/')
+    alias=$(echo ${filename} | sed -r 's/truststoreCert-(.*)\.crt$/\1/')
 
     SECRET_ARGS="${SECRET_ARGS} --from-file=truststoreCert-${alias}=${certfile}"
   fi


### PR DESCRIPTION
The script searched for files named "truststore-*.crt". If the truststore certificates were named after the readme.md or sample files (truststoreCert-*.crt), the search for truststore certificates would fail. 

Signed-off-by: Florian Wegert <florian.wegert@de.ibm.com>