### PR TITLE
[skip ci] Fix index 

### DIFF
--- a/repo/entitled/index.yaml
+++ b/repo/entitled/index.yaml
@@ -246,6 +246,23 @@ entries:
     urls:
     - https://raw.githubusercontent.com/IBM/charts/master/repo/entitled/ibm-apm-ema-bundle-prod-1.1.0+hotfix.1.tgz
     version: 1.1.0+hotfix.1
+  - apiVersion: v1
+    appVersion: "1.0"
+    created: "2020-02-29T05:27:24.527091796-08:00"
+    description: A Helm Chart for IBM Equipment Maintenance Assistant
+    digest: 0726d0b841552d42495d15886807c7003b034d2feade2d9eb5330b7013490c25
+    icon: https://raw.githubusercontent.com/IBM/charts/master/logo/ema.svg?sanitize=true
+    keywords:
+    - amd64
+    - Watson
+    - Commercial
+    - RHOCP
+    kubeVersion: '>=1.11'
+    name: ibm-apm-ema-bundle-prod
+    tillerVersion: '>=2.9.1'
+    urls:
+    - https://raw.githubusercontent.com/IBM/charts/master/repo/entitled/ibm-apm-ema-bundle-prod-1.1.0.tgz
+    version: 1.1.0
   ibm-apm-ema-prod:
   - apiVersion: v1
     appVersion: "1.0"


### PR DESCRIPTION
There is a slight problem with the `helm repo index --merge` option. 
The option seems to not be able to manage the `+hotfix` version.

I think that if we merge an update to the index to be correct, then the diff tool should not corrupt the file.

However, if we continue to have `+version` on the charts, we should see if helm can fix the command. I pulled the latest version and it continued to fail.
