### PR TITLE
Added arch property to ibm-db2 and ibm-db2warehouse charts

### DIFF
--- a/stable/ibm-db2/README.md
+++ b/stable/ibm-db2/README.md
@@ -152,6 +152,7 @@ You can get Db2 Community Edition container images from the IBM Cloud Container 
         --db-name STRING            the name of database to deplpy. The default value is BLUDB (optional). The length of the value must not exceed 8 characters
         --namespace STRING          namespace/project to install  into (required)
         --release-name STRING       release name for helm (required)
+        --arch STRING               architecture of the cluster (optional)
         --existing-pvc STRING       existing PersistentVolumeClaim to use for persistent storage
         --storage-class STRING      StorageClass to use to dynamically provision a volume. Use this option for NFS storage class.
                                     For advanced settings that require multiple storage classes, use help-opt-file instead.

--- a/stable/ibm-db2/ibm_cloud_pak/pak_extensions/common/db2u-install
+++ b/stable/ibm-db2/ibm_cloud_pak/pak_extensions/common/db2u-install
@@ -13,7 +13,7 @@ storage_args=""
 db_name="BLUDB"
 helm_file=""
 advanced_install="false"
-arch="amd64"
+arch="x86_64"
 accept_eula="false"
 
 validate(){

--- a/stable/ibm-db2/ibm_cloud_pak/pak_extensions/common/db2u-install
+++ b/stable/ibm-db2/ibm_cloud_pak/pak_extensions/common/db2u-install
@@ -13,7 +13,7 @@ storage_args=""
 db_name="BLUDB"
 helm_file=""
 advanced_install="false"
-arch="$(uname -p)"
+arch="amd64"
 accept_eula="false"
 
 validate(){
@@ -82,6 +82,10 @@ parse_command_line_arguments(){
             --release-name )
                 shift
                 release_name=$1
+                ;;
+            --arch )
+                shift
+                arch=$1
                 ;;
             --existing-pvc )
                 shift
@@ -180,10 +184,11 @@ usage(){
 Usage: ./$(basename $0) --db-type STRING --namespace STRING --release-name STRING [--existing-pvc STRING | --storage-class STRING | --helm-opt-file FILENAME ] [OTHER ARGUMENTS...]
 
     Install arguments:
-        --db-type STRING            the type of database to deplpy. Must be one of: db2wh, db2oltp (required)
-        --db-name STRING            the name of database to deplpy. The default value is BLUDB (optional). The length of the value must not exceed 8 characters
+        --db-type STRING            the type of database to deploy. Must be one of: db2wh, db2oltp (required)
+        --db-name STRING            the name of database to deploy. The default value is BLUDB (optional). The length of the value must not exceed 8 characters
         --namespace STRING          namespace/project to install ${PRODUCT} into (required)
         --release-name STRING       release name for helm (required)
+        --arch STRING               architecture of the cluster (optional)
         --existing-pvc STRING       existing PersistentVolumeClaim to use for persistent storage
         --storage-class STRING      StorageClass to use to dynamically provision a volume. Use this option for NFS storage class.
                                     For advanced settings that require multiple storage classes, use help-opt-file instead.

--- a/stable/ibm-db2warehouse/README.md
+++ b/stable/ibm-db2warehouse/README.md
@@ -153,6 +153,7 @@ You can get Db2 Warehouse container images from the IBM Cloud Container Registry
         --db-name STRING            the name of database to deplpy. The default value is BLUDB (optional). The length of the value must not exceed 8 characters
         --namespace STRING          namespace/project to install  into (required)
         --release-name STRING       release name for helm (required)
+        --arch STRING               architecture of the cluster (optional)
         --existing-pvc STRING       existing PersistentVolumeClaim to use for persistent storage
         --storage-class STRING      StorageClass to use to dynamically provision a volume. Use this option for NFS storage class.
                                     For advanced settings that require multiple storage classes, use help-opt-file instead.

--- a/stable/ibm-db2warehouse/ibm_cloud_pak/pak_extensions/common/db2u-install
+++ b/stable/ibm-db2warehouse/ibm_cloud_pak/pak_extensions/common/db2u-install
@@ -13,7 +13,7 @@ storage_args=""
 db_name="BLUDB"
 helm_file=""
 advanced_install="false"
-arch="amd64"
+arch="x86_64"
 accept_eula="false"
 
 validate(){

--- a/stable/ibm-db2warehouse/ibm_cloud_pak/pak_extensions/common/db2u-install
+++ b/stable/ibm-db2warehouse/ibm_cloud_pak/pak_extensions/common/db2u-install
@@ -13,7 +13,7 @@ storage_args=""
 db_name="BLUDB"
 helm_file=""
 advanced_install="false"
-arch="$(uname -p)"
+arch="amd64"
 accept_eula="false"
 
 validate(){
@@ -82,6 +82,10 @@ parse_command_line_arguments(){
             --release-name )
                 shift
                 release_name=$1
+                ;;
+            --arch )
+                shift
+                arch=$1
                 ;;
             --existing-pvc )
                 shift
@@ -180,10 +184,11 @@ usage(){
 Usage: ./$(basename $0) --db-type STRING --namespace STRING --release-name STRING [--existing-pvc STRING | --storage-class STRING | --helm-opt-file FILENAME ] [OTHER ARGUMENTS...]
 
     Install arguments:
-        --db-type STRING            the type of database to deplpy. Must be one of: db2wh, db2oltp (required)
-        --db-name STRING            the name of database to deplpy. The default value is BLUDB (optional). The length of the value must not exceed 8 characters
+        --db-type STRING            the type of database to deploy. Must be one of: db2wh, db2oltp (required)
+        --db-name STRING            the name of database to deploy. The default value is BLUDB (optional). The length of the value must not exceed 8 characters
         --namespace STRING          namespace/project to install ${PRODUCT} into (required)
         --release-name STRING       release name for helm (required)
+        --arch STRING               architecture of the cluster (optional)
         --existing-pvc STRING       existing PersistentVolumeClaim to use for persistent storage
         --storage-class STRING      StorageClass to use to dynamically provision a volume. Use this option for NFS storage class.
                                     For advanced settings that require multiple storage classes, use help-opt-file instead.


### PR DESCRIPTION
**Issue:**

When deploying DB2 charts to Kubernetes/Openshift from a mac or windows machine (running gitbash) the db2u-install script sets the `arch` helm value using `arch=$(uname -p)` This does not match the clusters architecture and causes pods not be deployed due to the following nodeSelector:

```
      nodeSelectorTerms:
      - matchExpressions:
        - key: beta.kubernetes.io/arch
          operator: In
          values: 
            - unknown
```

`unknown` has been set by my colleague running the script on her windows laptop(running gitbash) which returns `unknown` from `uname -p`

The script inserts this into the helm chart and currently there's no way of overriding it. 

**Solution:**

Default `arch` to `amd64` and add an optional parameter to allow the user to override it.


