### PR TITLE
[community/portworx] better support for customization

### DIFF
--- a/community/portworx/Chart.yaml
+++ b/community/portworx/Chart.yaml
@@ -1,5 +1,5 @@
 name: portworx
-version: 1.0.22
+version: 1.1.0
 description: A Helm chart for installing Portworx on Kubernetes.
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.10.0"

--- a/community/portworx/templates/csi-clusterrole.yaml
+++ b/community/portworx/templates/csi-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- if and (.Values.csi) (eq .Values.csi true) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/community/portworx/templates/csi-clusterrolebinding.yaml
+++ b/community/portworx/templates/csi-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- if and (.Values.csi) (eq .Values.csi true) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/community/portworx/templates/csi-deployment.yaml
+++ b/community/portworx/templates/csi-deployment.yaml
@@ -16,7 +16,12 @@ spec:
       labels:
         app: px-csi-driver
     spec:
+      tolerations:
+      {{- .Values.portworx.csi.tolerations | toYaml | nindent 8 }}
       affinity:
+      {{- if .Values.portworx.csi.affinity }}
+        {{- .Values.portworx.csi.affinity | toYaml | nindent 8 }}
+      {{- else }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -27,6 +32,7 @@ spec:
                 - "false"
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
+        {{- end }}
       serviceAccount: px-csi-account
       containers:
         - name: csi-external-provisioner

--- a/community/portworx/templates/csi-deployment.yaml
+++ b/community/portworx/templates/csi-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- if and (.Values.csi) (eq .Values.csi true) }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/community/portworx/templates/csi-driver.yaml
+++ b/community/portworx/templates/csi-driver.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- if and (.Values.csi) (eq .Values.csi true) }}
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:

--- a/community/portworx/templates/csi-service.yaml
+++ b/community/portworx/templates/csi-service.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- if and (.Values.csi) (eq .Values.csi true) }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/community/portworx/templates/csi-serviceaccount.yaml
+++ b/community/portworx/templates/csi-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- if and (.Values.csi) (eq .Values.csi true) }}
 {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
 apiVersion: v1
 kind: ServiceAccount

--- a/community/portworx/templates/lighthouse-clusterrole.yaml
+++ b/community/portworx/templates/lighthouse-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.lighthouse) and (eq .Values.lighthouse true) -}}
+{{- if and (.Values.lighthouse) (eq .Values.lighthouse true) -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/community/portworx/templates/lighthouse-clusterrolebinding.yaml
+++ b/community/portworx/templates/lighthouse-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.lighthouse) and (eq .Values.lighthouse true) -}}
+{{- if and (.Values.lighthouse) (eq .Values.lighthouse true) -}}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/community/portworx/templates/lighthouse-deployment.yaml
+++ b/community/portworx/templates/lighthouse-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.lighthouse) and (eq .Values.lighthouse true) -}}
+{{- if and (.Values.lighthouse) (eq .Values.lighthouse true) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/community/portworx/templates/lighthouse-service.yaml
+++ b/community/portworx/templates/lighthouse-service.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.lighthouse) and (eq .Values.lighthouse true) -}}
+{{- if and (.Values.lighthouse) (eq .Values.lighthouse true) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/community/portworx/templates/lighthouse-serviceaccount.yaml
+++ b/community/portworx/templates/lighthouse-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.lighthouse) and (eq .Values.lighthouse true) -}}
+{{- if and (.Values.lighthouse) (eq .Values.lighthouse true) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/community/portworx/templates/portworx-api.yaml
+++ b/community/portworx/templates/portworx-api.yaml
@@ -53,7 +53,12 @@ spec:
         name: portworx-api
 {{- include "px.labels" . | nindent 8 }}
     spec:
+      tolerations:
+      {{- .Values.portworx.api.tolerations | toYaml | nindent 8 }}
       affinity:
+      {{- if .Values.portworx.api.affinity }}
+        {{- .Values.portworx.api.affinity | toYaml | nindent 8 }}
+      {{- else }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -66,6 +71,7 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
                 {{- end }}
+      {{- end }}
       hostNetwork: true
       hostPID: false
       containers:

--- a/community/portworx/templates/portworx-ds.yaml
+++ b/community/portworx/templates/portworx-ds.yaml
@@ -51,7 +51,12 @@ spec:
         name: portworx
 {{- include "px.labels" . | nindent 8 }}
     spec:
+      tolerations:
+      {{- .Values.portworx.tolerations | toYaml | nindent 8 }}
       affinity:
+      {{- if .Values.portworx.affinity }}
+        {{- .Values.portworx.affinity | toYaml | nindent 8 }}
+      {{- else }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -67,6 +72,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+        {{- end }}
       hostNetwork: true
       hostPID: true
       {{- if not (eq $registrySecret "none") }}

--- a/community/portworx/templates/portworx-pvc-controller.yaml
+++ b/community/portworx/templates/portworx-pvc-controller.yaml
@@ -78,7 +78,7 @@ spec:
   selector:
     matchLabels:
       name: portworx-pvc-controller
-  replicas: 3
+  replicas: {{ .Values.portworx.pvc.replicas }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -123,7 +123,12 @@ spec:
           requests:
             cpu: 200m
       hostNetwork: true
+      tolerations:
+      {{- .Values.portworx.pvc.tolerations | toYaml | nindent 8 }}
       affinity:
+      {{- if .Values.portworx.pvc.affinity }}
+        {{- .Values.portworx.pvc.affinity | toYaml | nindent 8 }}
+      {{- else }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -133,5 +138,6 @@ spec:
                     values:
                     - portworx-pvc-controller
               topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       serviceAccountName: portworx-pvc-controller-account
 {{- end -}}

--- a/community/portworx/templates/stork-deployment.yaml
+++ b/community/portworx/templates/stork-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       maxSurge: 1
       maxUnavailable: 1
     type: RollingUpdate
-  replicas: 3
+  replicas: {{ .Values.strok.replicas }}
   selector:
     matchLabels:
         name: stork
@@ -54,7 +54,12 @@ spec:
             drop:
             - ALL
       hostPID: false
+      tolerations:
+      {{- .Values.strok.tolerations | toYaml | nindent 8 }}
       affinity:
+      {{- if .Values.strok.affinity }}
+        {{- .Values.strok.affinity | toYaml | nindent 8 }}
+      {{- else }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -72,4 +77,5 @@ spec:
                 operator: In
                 values:
                 - amd64
+      {{- end }}
       serviceAccountName: stork-account

--- a/community/portworx/templates/stork-scheduler-deployment.yaml
+++ b/community/portworx/templates/stork-scheduler-deployment.yaml
@@ -50,7 +50,12 @@ spec:
           capabilities:
             drop:
             - ALL
+      tolerations:
+      {{- .Values.strok.scheduler.tolerations | toYaml | nindent 8 }}
       affinity:
+      {{- if .Values.strok.scheduler.affinity }}
+        {{- .Values.strok.scheduler.affinity | toYaml | nindent 8 }}
+      {{- else }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -68,5 +73,6 @@ spec:
                 operator: In
                 values:
                 - amd64
+      {{- end }}
       hostPID: false
       serviceAccountName: stork-scheduler-account

--- a/community/portworx/values.yaml
+++ b/community/portworx/values.yaml
@@ -45,3 +45,56 @@ serviceAccount:
   hook:
     create: true
     name:
+
+portworx:
+  # Tolerations for pod assignment.
+  # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+  ## Affinity for pod assignment.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Advanced option, make sure you have review the default in the portworx DaemonSet
+  affinity: {}
+  api:
+    # Tolerations for pod assignment.
+    # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+    ## Affinity for pod assignment.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## Advanced option, make sure you have review the default in the portworx-api DaemonSet
+    affinity: {}
+  pvc:
+    replicas: 3
+    # Tolerations for pod assignment.
+    # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+    ## Affinity for pod assignment.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## Advanced option, make sure you have review the default in the portworx-pvc-controller Deployment
+    affinity: {}
+  csi:
+    replicas: 3
+    # Tolerations for pod assignment.
+    # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+    ## Affinity for pod assignment.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## Advanced option, make sure you have review the default in the px-csi-ext Deployment
+    affinity: {}
+
+strok:
+  replicas: 3
+  # Tolerations for pod assignment.
+  # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+  ## Affinity for pod assignment.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Advanced option, make sure you have review the default in the stroke Deployment
+  affinity: {}
+  scheduler:
+    # Tolerations for pod assignment.
+    # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+    ## Affinity for pod assignment.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## Advanced option, make sure you have review the default in the strok-scheduler-deployment Deployment
+    affinity: {}


### PR DESCRIPTION
This PR introduces the following change

## Features

### Add `tolerations`

It's quite common to taint a subset of worker nodes or a specific workerpool for different usage. For example, we have a dedicated workerpool optimized for high performance storage, and we only want service (databases) that actually need the optimized storage to run on these nodes

### Able to override `affinity` as needed

This is more of an advanced option. It is documented in the `values.yaml` that user should review the default configuration before making any changes.

### Fixs

A whole bunch of flow control function usage is wrong. Make `helm lint` happy

Before

```bash
➜  portworx git:(master) ✗ helm lint --set kvdb="stuff" .
==> Linting .
[ERROR] templates/: template: portworx/templates/lighthouse-serviceaccount.yaml:1:7: executing "portworx/templates/lighthouse-serviceaccount.yaml" at <(.Values.lighthouse) and (eq .Values.lighthouse true)>: can't give argument to non-function .Values.lighthouse

Error: 1 chart(s) linted, 1 chart(s) failed
```

After

```bash
➜  portworx git:(community/portworx/improve-chart) ✗ helm lint --set kvdb="stuff" .
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```

## Testing

You may download https://gist.github.com/ExiaSR/044b832d4ca1d975fc46be2d03793a2e the values override and run

```bash
helm template --values ./test-values.yaml .
```