### PR TITLE
fixes for GKE, add flexible ingressClass

### DIFF
--- a/entitled/ibm-odm-prod/templates/ingress.yaml
+++ b/entitled/ibm-odm-prod/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
 
 spec:
   {{- if and (not (empty ( .Values.service.ingress.tlsHosts ))) (not (empty ( .Values.service.ingress.tlsSecretRef ))) }}
+  {{- if not (empty ( .Values.service.ingress.className )) }}
+  ingressClassName: {{ .Values.service.ingress.className }}
+  {{- end }}
   tls:
   - hosts:
     {{- range .Values.service.ingress.tlsHosts }}
@@ -30,7 +33,7 @@ spec:
   {{- end }}
       paths:
       {{- if or .Values.decisionServerRuntime.enabled .Values.decisionRunner.enabled }}
-      - path: {{ .Values.decisionServerConsole.contextRoot }}/res
+      - path: {{ .Values.decisionServerConsole.contextRoot }}
         pathType: Prefix
         backend:
           service :
@@ -39,14 +42,14 @@ spec:
               number: 9443
       {{- end }}
       {{- if .Values.decisionCenter.enabled }}
-      - path: {{ .Values.decisionCenter.contextRoot }}/decisioncenter
+      - path: {{ .Values.decisionCenter.contextRoot }}
         pathType: Prefix
         backend:
           service:
             name: {{ template "odm.decisioncenter.fullname" . }}
             port:
               number: 9453
-      - path: {{ .Values.decisionCenter.contextRoot }}/decisioncenter-api
+      - path: {{ .Values.decisionCenter.apiContextRoot }}
         pathType: Prefix
         backend:
           service:
@@ -55,7 +58,7 @@ spec:
               number: 9453
       {{- end }}
       {{- if .Values.decisionServerRuntime.enabled }}
-      - path: {{ .Values.decisionServerRuntime.contextRoot }}/DecisionService
+      - path: {{ .Values.decisionServerRuntime.contextRoot }}
         pathType: Prefix
         backend:
           service:
@@ -64,7 +67,7 @@ spec:
               number: 9443
       {{- end }}
       {{- if .Values.decisionRunner.enabled }}
-      - path: {{ .Values.decisionRunner.contextRoot }}/DecisionRunner
+      - path: {{ .Values.decisionRunner.contextRoot }}
         pathType: Prefix
         backend:
           service:

--- a/entitled/ibm-odm-prod/values.yaml
+++ b/entitled/ibm-odm-prod/values.yaml
@@ -29,6 +29,8 @@ service:
     tlsHosts: []
     tlsSecretRef:
     host:
+    # Can be set to nginx, istio, or any other ingressClass
+    className:
 
 decisionServerRuntime:
   enabled: true
@@ -54,7 +56,8 @@ decisionServerRuntime:
         memory: 200Mi
     existingClaimName:
     env:
-  contextRoot:
+  # Note that GKE should use /DecisionService/ if not using the nginx ingress
+  contextRoot: /DecisionService
   resources:
     requests:
       cpu: 500m
@@ -91,7 +94,8 @@ decisionServerConsole:
         memory: 200Mi
     existingClaimName:
     env:
-  contextRoot:
+  # Note that GKE should use /res/login.jsf if not using the nginx ingress
+  contextRoot: /res
   resources:
     requests:
       cpu: 500m
@@ -126,7 +130,9 @@ decisionCenter:
         memory: 200Mi
     existingClaimName:
     env:
-  contextRoot:
+  # Note that GKE should use /decisioncenter/healthcheck if not using the nginx ingress
+  contextRoot: /decisioncenter
+  apiContextRoot: /decisioncenter-api
   refererList:
   resources:
     requests:
@@ -165,7 +171,8 @@ decisionRunner:
         memory: 200Mi
     existingClaimName:
     env:
-  contextRoot:
+  # Note that GKE should use /DecisionRunner/ if not using the nginx ingress
+  contextRoot: /DecisionRunner
   resources:
     requests:
       cpu: 500m


### PR DESCRIPTION
Changes:

- Move the contextRoots out to the values.yaml to avoid magic string interpolation
- Add the ability to specify an ingressClass
- Add comments to help GKE users figure out whats going on
- Do not disturb existing charts, chart renders the same 