### PR TITLE
Portworx fixes.

### DIFF
--- a/community/portworx/templates/_helpers.tpl
+++ b/community/portworx/templates/_helpers.tpl
@@ -13,7 +13,7 @@ helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
 {{- define "px.metering.annotations" -}}
 productName: "PX-Enterprise"
 productID: com.portworx.enterprise
-productVersion: {{ .Values.imageVersion }}
+productVersion: {{ quote .Values.imageVersion }}
 {{- end -}}
 
 {{- define "px.kubernetesVersion" -}}

--- a/community/portworx/templates/csi-driver.yaml
+++ b/community/portworx/templates/csi-driver.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.csi (eq .Values.csi true)}}
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: pxd.portworx.com

--- a/community/portworx/templates/hooks/post-delete/px-postdelete-unlabelnode.yaml
+++ b/community/portworx/templates/hooks/post-delete/px-postdelete-unlabelnode.yaml
@@ -21,7 +21,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/community/portworx/templates/hooks/pre-delete/px-predelete-nodelabel.yaml
+++ b/community/portworx/templates/hooks/pre-delete/px-predelete-nodelabel.yaml
@@ -21,7 +21,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/community/portworx/templates/hooks/pre-install/etcd-preinstall-hook.yaml
+++ b/community/portworx/templates/hooks/pre-install/etcd-preinstall-hook.yaml
@@ -21,7 +21,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/community/portworx/templates/portworx-ds.yaml
+++ b/community/portworx/templates/portworx-ds.yaml
@@ -64,13 +64,6 @@ spec:
                 operator: NotIn
                 values:
                 - "false"
-              - key: node-role.kubernetes.io/master
-                operator: DoesNotExist
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
       hostNetwork: true
       hostPID: true
       {{- if not (eq $registrySecret "none") }}

--- a/community/portworx/templates/stork-deployment.yaml
+++ b/community/portworx/templates/stork-deployment.yaml
@@ -68,7 +68,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/community/portworx/templates/stork-scheduler-deployment.yaml
+++ b/community/portworx/templates/stork-scheduler-deployment.yaml
@@ -69,7 +69,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/community/portworx/templates/test/test-portworx-api.yaml
+++ b/community/portworx/templates/test/test-portworx-api.yaml
@@ -15,7 +15,7 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: beta.kubernetes.io/arch
+          - key: kubernetes.io/arch
             operator: In
             values:
             - "amd64"


### PR DESCRIPTION
1. Moved CSIDriver version to v1.
2. Moved `beta.kubernetes.io/arch` annotation to `kubernetes.io/arch`