### PR TITLE
Update health check endpoints for ODM 9.5.0.1 Decision Center deployment on OpenShift

### DIFF
--- a/entitled/ibm-odm-prod/templates/dc-deployment.yaml
+++ b/entitled/ibm-odm-prod/templates/dc-deployment.yaml
@@ -198,7 +198,7 @@ spec:
         - name: dc-port
           containerPort: 9060
         {{- end }}
-{{ include "odm-probe-container-template" (dict "root" . "componentPath" "decisioncenter/healthCheck" "port" "dc-port" "containerParameters" .Values.decisionCenter )  | indent 8 }}
+{{ include "odm-probe-container-template" (dict "root" . "componentPath" "decisioncenter" "port" "dc-port" "containerParameters" .Values.decisionCenter )  | indent 8 }}
         env:
 {{ include "odm-security-config" . | indent 10 }}
 {{ include "odm-db-config"  (dict "componentName" "decisionCenter" "root" .) | indent 10 }}


### PR DESCRIPTION
The current version of ODM 9.5.0.1 Helm Chart deployment doesn't have **/decisioncenter/healthCheck** health endpoint. I have opened a IBM case to understand if this exists and have been advised by support engineer this no longer exist, instead recommended to use **/decisioncenter** or **/decisioncenter-api** for the Decision Center component deployed on OpenShift.